### PR TITLE
Added parties tracker and placeholder to display it

### DIFF
--- a/src/main/kotlin/me/clip/voteparty/VoteParty.kt
+++ b/src/main/kotlin/me/clip/voteparty/VoteParty.kt
@@ -11,6 +11,7 @@ import me.clip.voteparty.conf.sections.HookSettings
 import me.clip.voteparty.conf.sections.PartySettings
 import me.clip.voteparty.conf.sections.PluginSettings
 import me.clip.voteparty.conf.sections.VoteData
+import me.clip.voteparty.data.impl.PartiesCacheGson
 import me.clip.voteparty.data.impl.VotedForPartyCacheGson
 import me.clip.voteparty.exte.color
 import me.clip.voteparty.exte.runTaskTimerAsync
@@ -39,7 +40,6 @@ import java.io.InputStream
 import java.util.Locale
 import java.util.logging.Level
 
-
 class VoteParty internal constructor(internal val plugin: VotePartyPlugin) : State
 {
 
@@ -58,6 +58,7 @@ class VoteParty internal constructor(internal val plugin: VotePartyPlugin) : Sta
 	private val votesListener = VotesListener(plugin)
 	private val hooksListener = HooksListenerNuVotifier(plugin)
 	private val votedForPartyCache = VotedForPartyCacheGson(plugin)
+	private val partiesCache = PartiesCacheGson(plugin)
 
 	private var hook = null as? VersionHook?
 	private var papi = null as? VotePartyPlaceholders?
@@ -92,6 +93,9 @@ class VoteParty internal constructor(internal val plugin: VotePartyPlugin) : Sta
 		// voted for party cache
 		votedForPartyCache.load()
 
+		// parties cache
+		partiesCache.load()
+
 		if (conf().getProperty(HookSettings.NUVOTIFIER))
 		{
 			hooksListener.load()
@@ -125,6 +129,7 @@ class VoteParty internal constructor(internal val plugin: VotePartyPlugin) : Sta
 		usersHandler.kill()
 		leaderboardHandler.kill()
 		votedForPartyCache.kill()
+		partiesCache.kill()
 	}
 
 

--- a/src/main/kotlin/me/clip/voteparty/data/base/PartiesCache.kt
+++ b/src/main/kotlin/me/clip/voteparty/data/base/PartiesCache.kt
@@ -1,0 +1,13 @@
+package me.clip.voteparty.data.base
+
+import me.clip.voteparty.base.Addon
+import me.clip.voteparty.base.State
+
+internal interface PartiesCache : Addon, State {
+
+    override fun load()
+
+    override fun kill()
+
+    fun save()
+}

--- a/src/main/kotlin/me/clip/voteparty/data/impl/PartiesCacheGson.kt
+++ b/src/main/kotlin/me/clip/voteparty/data/impl/PartiesCacheGson.kt
@@ -1,0 +1,71 @@
+package me.clip.voteparty.data.impl
+
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.reflect.TypeToken
+import java.io.File
+import java.util.logging.Level
+import me.clip.voteparty.data.base.PartiesCache
+import me.clip.voteparty.plugin.VotePartyPlugin
+
+class PartiesCacheGson(override val plugin: VotePartyPlugin) : PartiesCache {
+
+    private lateinit var gson: Gson
+    private lateinit var file: File
+    private lateinit var backupFile: File
+    private val type = object : TypeToken<MutableList<Long>>() {}.type
+
+    override fun load() {
+        val builder = GsonBuilder().setPrettyPrinting()
+        gson = builder.create()
+
+        file = plugin.dataFolder.resolve("parties.json")
+        backupFile = plugin.dataFolder.resolve("parties.json.bak")
+
+        if (!file.exists()) {
+            file.parentFile.mkdirs()
+            file.createNewFile()
+        }
+
+        try
+        {
+            party.partyHandler.setParties(gson.fromJson(file.readText(), type))
+        }
+        catch (exception: Exception)
+        {
+            logger.log(
+                Level.SEVERE,
+                "failed to load voted for party cache. This can end up in data loss!" + System.lineSeparator() +
+                        "A backup of the ${file.name} file was saved to: ${backupFile.name}",
+                exception
+            )
+
+            if (!backupFile.exists()) {
+                backupFile.mkdirs()
+                backupFile.createNewFile()
+            }
+
+            backupFile.writeText(file.readText())
+        }
+    }
+
+    override fun kill() {
+        save()
+    }
+
+    override fun save() {
+        try
+        {
+            file.writeText(gson.toJson(party.partyHandler.getParties(), type))
+        }
+        catch (exception: Exception)
+        {
+            logger.log(
+                Level.SEVERE,
+                "failed to save parties cache. This can end up in data loss!" + System.lineSeparator() +
+                        "For backup purposes, the cached data is: " + party.partyHandler.getParties().joinToString(", "),
+                exception
+            )
+        }
+    }
+}

--- a/src/main/kotlin/me/clip/voteparty/handler/PartyHandler.kt
+++ b/src/main/kotlin/me/clip/voteparty/handler/PartyHandler.kt
@@ -1,5 +1,7 @@
 package me.clip.voteparty.handler
 
+import java.time.LocalDateTime
+import java.time.ZoneId
 import me.clip.voteparty.base.Addon
 import me.clip.voteparty.conf.sections.CrateSettings
 import me.clip.voteparty.conf.sections.EffectsSettings
@@ -29,6 +31,28 @@ class PartyHandler(override val plugin: VotePartyPlugin) : Addon
 {
 
 	var voted = mutableListOf<UUID>()
+	private var parties = mutableListOf<Long>()
+
+	fun getParties(): MutableList<Long> {
+		return parties
+	}
+
+	fun setParties(new: MutableList<Long>)
+	{
+		parties = new
+	}
+
+	fun addParties(vararg new: Long)
+	{
+		new.forEach { parties.add(it) }
+	}
+
+	fun getPartiesSince(time: LocalDateTime): Int
+	{
+		val timeEpoch = time.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+		return parties.count { partyEpoch -> partyEpoch > timeEpoch }
+	}
 
 	fun giveRandomPartyRewards(player: Player)
 	{
@@ -172,6 +196,7 @@ class PartyHandler(override val plugin: VotePartyPlugin) : Addon
 				return@runTaskLater
 			}
 
+			addParties(System.currentTimeMillis())
 			runPartyCommands()
 			runPartyStartEffects()
 

--- a/src/main/kotlin/me/clip/voteparty/placeholders/VotePartyPlaceholders.kt
+++ b/src/main/kotlin/me/clip/voteparty/placeholders/VotePartyPlaceholders.kt
@@ -43,6 +43,10 @@ class VotePartyPlaceholders(private val voteParty: VoteParty) : PlaceholderExpan
 			return getVotes(arg.replace("totalvotes_", "").lowercase(Locale.getDefault()), player ?: return "")
 		}
 
+		if (arg.startsWith("totalparties_")) {
+			return getParties(arg.replace("totalparties_", "").lowercase(Locale.getDefault()))
+		}
+
 		return when (arg.lowercase(Locale.getDefault())) {
 			"votes_recorded" -> voteParty.getVotes().toString()
 			"votes_required_party" -> voteParty.getVotesNeeded().minus(voteParty.getVotes()).toString()
@@ -91,6 +95,14 @@ class VotePartyPlaceholders(private val voteParty: VoteParty) : PlaceholderExpan
 	private fun getVotes(input: String, player: OfflinePlayer): String
 	{
 		return LeaderboardType.find(input)?.let { voteParty.usersHandler.getVotesSince(player, it.time.invoke()) }?.toString() ?: ""
+	}
+
+	/**
+	 * Get the amount of parties that have been triggered based on the given leaderboard type
+	 */
+	private fun getParties(input: String): String
+	{
+		return LeaderboardType.find(input)?.let { voteParty.partyHandler.getPartiesSince(it.time.invoke()) }?.toString() ?: ""
 	}
 
 }


### PR DESCRIPTION
This stores each party when it happens in a new file called `parties.json`. It stores them the same way votes are stored: by their timestamps. This way people can use placeholders to see how many parties triggered in the past day, week, month, year and the total/alltime.

The placeholder for this will be: `%voteparty_totalparties_TYPE%`.

I intensively tested this but it was all done in a limited amount of time but by manually editing the parties.json, it all seems to work just fine:

![image](https://user-images.githubusercontent.com/52609756/193868649-8dfb3ace-21c4-466b-90e3-fb7cc66a0465.png)
![image](https://user-images.githubusercontent.com/52609756/193868671-3582a4ff-5be3-4e5f-a57a-79ed14e36a2d.png)

Closes #46.

P.S. In case this does get merged during October, would appreciate it having the hacktoberfest-accepted label added sweat_smile