### PR TITLE
fix: don't recalculate getPlayersWhoVotedSince for each online player

### DIFF
--- a/src/main/kotlin/me/clip/voteparty/handler/PartyHandler.kt
+++ b/src/main/kotlin/me/clip/voteparty/handler/PartyHandler.kt
@@ -209,7 +209,11 @@ class PartyHandler(override val plugin: VotePartyPlugin) : Addon
 
 			val targets: Collection<Player> = when(party.conf().getProperty(PartySettings.PARTY_MODE)) {
 				"everyone" -> server.onlinePlayers
-				"daily" -> server.onlinePlayers.filter { party.usersHandler.getPlayersWhoVotedSince(1, TimeUnit.DAYS).contains(it.uniqueId) }
+				"daily" -> {
+					val playersWhoVotedSince = party.usersHandler.getPlayersWhoVotedSince(1, TimeUnit.DAYS)
+
+					server.onlinePlayers.filter { playersWhoVotedSince.contains(it.uniqueId) }
+				}
 				"party" -> server.onlinePlayers.filter { voted.contains(it.uniqueId) }
 				else -> server.onlinePlayers
 			}


### PR DESCRIPTION
We noticed a ~1 second hang at each vote party. The bulk of it is from `UsersHandler.getPlayersWhoVotedSince` being in the filter loop. This PR brings it out, so it's called once, rather than for each player

![image](https://github.com/user-attachments/assets/39877b7c-c827-47db-bf13-51eb3347e432)
